### PR TITLE
ignore it

### DIFF
--- a/velero-plugin-for-microsoft-azure/common.go
+++ b/velero-plugin-for-microsoft-azure/common.go
@@ -77,6 +77,10 @@ func parseAzureEnvironment(cloudName string) (*azure.Environment, error) {
 	}
 
 	env, err := azure.EnvironmentFromName(cloudName)
+	// ensure that Azure REST authorizer is also set to the Azure environment
+	if err == nil {
+		os.Setenv("AZURE_ENVIRONMENT", env.Name)
+	}
 	return &env, errors.WithStack(err)
 }
 


### PR DESCRIPTION
ensure that env var `AZURE_ENVIRONMENT` is set to the parsed cloud so that the Azure REST authoriser is contacting the correct endpoint url